### PR TITLE
Fix for Issue #12

### DIFF
--- a/src/main/groovy/org/jboss/gradle/plugins/jdocbook/book/Book.groovy
+++ b/src/main/groovy/org/jboss/gradle/plugins/jdocbook/book/Book.groovy
@@ -93,7 +93,12 @@ class Book {
     }
 
     def format(String name, Closure closure) {
-        format(ConfigureUtil.configure(closure, new FormatOption(name)))
+		// if name is null then sometimes! the wrong ctor gets called. 
+		// calls FormatOption(FormatOption parent)
+		// appears to be platform dependent
+		def fo = name ? new FormatOption(name) : new FormatOption()
+		def config = ConfigureUtil.configure(closure, fo)
+        format(config)
     }
 
     def format(FormatOption f) {


### PR DESCRIPTION
Fixed crash where wrong ctor was sometimes called. Appears to be platform and JVM dependent. 
Crash was consistent on Linux with Java7. The problem is that the FormatOption class has 2 single param ctors. Line 92 of Book.groovy calls the modifed method with null for the name param. This then in turn calls new FormatOption(null), which on Linux/Java7 calls the FormatOption(FormatOption parent) ctor not the FormatOption(String name) ctor as apparently happens on other platforms and on Linux with Java6.
